### PR TITLE
Update azure-files-csi.md

### DIFF
--- a/articles/aks/azure-files-csi.md
+++ b/articles/aks/azure-files-csi.md
@@ -227,6 +227,21 @@ az provider register --namespace Microsoft.Storage
 - secure transfer required(enable HTTPS traffic only): false
 - select the virtual network of your agent nodes in Firewalls and virtual networks
 
+### Install the azurefile CSI driver on the cluster
+
+```console
+curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/v0.9.0/deploy/install-driver.sh | bash -s v0.9.0 --
+```
+
+You can verify is the driver was installed by checking the status of the pods that comprise the solution:
+```console
+kubectl -n kube-system get pod -o wide --watch -l app=csi-azurefile-controller
+kubectl -n kube-system get pod -o wide --watch -l app=csi-azurefile-node
+```
+
+> [!NOTE]
+> If the cluster was created using Managed Identity, make sure the assigned identity has *Contributor* role on the Storage Account. 
+
 ### Create NFS file share storage class
 
 Save a `nfs-sc.yaml` file with the manifest below editing the respective placeholders.
@@ -255,7 +270,7 @@ storageclass.storage.k8s.io/azurefile-csi created
 You can deploy an example [stateful set](https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/deploy/example/statefulset.yaml) that saves timestamps into a file `data.txt` by deploying the following command with the [kubectl apply][kubectl-apply] command:
 
  ```console
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/deploy/example/windows/statefulset.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/deploy/example/statefulset.yaml
 
 statefulset.apps/statefulset-azurefile created
 ```


### PR DESCRIPTION
Hi -

I few proposed changes:

1. Added a section on installing the azurefile CSI on the Cluster - I'm adding the instructions here for v0.9.0 as per https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/docs/install-azurefile-csi-driver.md
1. Added a NOTE when using Managed Identities on a cluster as you need to add the MI into the Storage Account IAM as a Contributor.
2. changing the statefulset to point to the Linux based image (the example here is running `df -h` on a Linux image).

These changes were tested on AKS 1.18.8 on eastus2 using the azurefile-csi driver v0.9.0